### PR TITLE
fix bug when appending to empty column

### DIFF
--- a/src/DataColumn.c
+++ b/src/DataColumn.c
@@ -49,7 +49,7 @@ dt_column_create(
 	if (!*column)
 		return DT_ALLOC_ERROR;
 
-	(*column)->value = calloc(capacity * 2, get_type_size(type));
+	(*column)->value = calloc(capacity * 2 + 1, get_type_size(type));
 	if (!(*column)->value)
 	{
 		free(*column);
@@ -59,7 +59,7 @@ dt_column_create(
 	(*column)->type = type;
 	(*column)->type_size = get_type_size(type);
 	(*column)->n_values = capacity;
-	(*column)->value_capacity = capacity * 2;
+	(*column)->value_capacity = capacity * 2 + 1;
 
 	return DT_SUCCESS;
 }

--- a/test/DataColumn/dt_column_append_value.c
+++ b/test/DataColumn/dt_column_append_value.c
@@ -17,12 +17,25 @@ int main()
 
 	if (get != set)
 	{
-		fprintf(stderr, "Was expected value %d but got %d instead.\n", set, get);
+		fprintf(stderr, "Was expecting value %d but got %d instead.\n", set, get);
+		goto cleanup;
+	}
+
+	// test appending with empty column
+	struct DataColumn* empty = NULL;
+	dt_column_create(&empty, 0, INT32);
+	dt_column_append_value(empty, &set);
+	dt_column_get_value(empty, 0, &get);
+
+	if (get != set)
+	{
+		fprintf(stderr, "Was expecting value %d but got %d instead.\n", set, get);
 		goto cleanup;
 	}
 
 	status = 0;
 cleanup:
 	dt_column_free(&column);
+	dt_column_free(&empty);
 	return status;
 }

--- a/test/DataColumn/dt_column_create.c
+++ b/test/DataColumn/dt_column_create.c
@@ -24,8 +24,8 @@ int main()
 		return -1;
 	}
 
-	// the internal capacity is actually doubled but the "logical" size is still 5
-	if (column->value_capacity != 10)
+	// the internal capacity is actually doubled (and incremented by 1) but the "logical" size is still 5
+	if (column->value_capacity != 11)
 	{
 		fprintf(stderr, "Expecting capacity of 10 but got %zu.\n", column->value_capacity);
 		goto cleanup;


### PR DESCRIPTION
capacity was 0 if empty column is created, so we increment the capacity by one when creating a new column