### PR TITLE
(#63) drop rows/columns with null values

### DIFF
--- a/include/DataColumn.h
+++ b/include/DataColumn.h
@@ -155,6 +155,15 @@ dt_column_subset_by_index(
 	const size_t* const indices,
 	const size_t n_indices);
 
+// drop all rows containing index (opposite of dt_column_subset_by_index)
+// NOTE: this expects the indices to be PRE-SORTED ASCENDING using qsort()
+// returns NULL on failure (e.g., if one of the indices is out of bounds)
+struct DataColumn*
+dt_column_drop_by_index(
+	const struct DataColumn* const column,
+	const size_t* const sorted_indices_ascending,
+	const size_t n_indices);
+
 // resize a column to new size with n_values.
 // returns DT_ALLOC_ERROR if reallocation fails, DT_SUCCESS otherwise.
 // if new size is bigger, values are defaulted to 0.

--- a/include/DataTable.h
+++ b/include/DataTable.h
@@ -240,4 +240,16 @@ dt_table_drop_columns_by_name(
 	const size_t n_columns,
 	const char (*columns)[MAX_COL_LEN]);
 
+// drop any columns containing at least one NULL value in a row.
+// modifies the table inplace
+void
+dt_table_drop_columns_with_null(
+	struct DataTable* table);
+
+// drop any rows containing at least one NULL value in a column
+// modifies the table inplace
+enum status_code_e
+dt_table_drop_rows_with_null(
+	struct DataTable* table);
+
 #endif

--- a/test/DataTable/CMakeLists.txt
+++ b/test/DataTable/CMakeLists.txt
@@ -67,3 +67,8 @@ add_executable(dt_table_drop_columns dt_table_drop_columns.c)
 target_include_directories(dt_table_drop_columns PUBLIC ${DataTable_SOURCE_DIR}/include)
 target_link_libraries(dt_table_drop_columns datatable)
 add_test(NAME dt_table_drop_columns COMMAND dt_table_drop_columns)
+
+add_executable(dt_table_drop_null dt_table_drop_null.c)
+target_include_directories(dt_table_drop_null PUBLIC ${DataTable_SOURCE_DIR}/include)
+target_link_libraries(dt_table_drop_null datatable)
+add_test(NAME dt_table_drop_null COMMAND dt_table_drop_null)

--- a/test/DataTable/dt_table_drop_null.c
+++ b/test/DataTable/dt_table_drop_null.c
@@ -1,0 +1,59 @@
+#include "DataTable.h"
+#include <stdio.h>
+
+int main()
+{
+	int status = -1;
+
+	char colnames[2][MAX_COL_LEN] = { "col1", "col2" };
+	enum data_type_e types[2] = { INT32, FLOAT };
+	struct DataTable* table = dt_table_create(2, colnames, types);
+
+	int32_t set1 = 10;
+	float set2 = 5.5f;
+	dt_table_insert_row(table, 2, &set1, NULL);
+
+	set1 = 20;
+	set2 = 12.52f;
+	dt_table_insert_row(table, 2, &set1, &set2);
+
+	set2 = 21.21f;
+	dt_table_insert_row(table, 2, &set1, NULL);
+
+	struct DataTable* table2 = dt_table_copy(table);
+	dt_table_drop_columns_with_null(table2);
+
+	if (table2->n_columns != 1)
+	{
+		fprintf(stderr, "Expected 1 column after droping columns but have %zu.\n", table2->n_columns);
+		goto cleanup;
+	}
+
+	if (strcmp(table2->columns[0].name, "col1") != 0)
+	{
+		fprintf(stderr, "Expected column name to be 'col1' but got '%s'.\n", table2->columns[0].name);
+		goto cleanup;
+	}
+
+	if (table2->columns[0].column->type != INT32)
+	{
+		fprintf(stderr, "Expected column type to be INT32\n");
+		goto cleanup;
+	}
+
+	struct DataTable* table3 = dt_table_copy(table);
+	dt_table_drop_rows_with_null(table3);
+
+	if (table3->n_rows != 1)
+	{
+		fprintf(stderr, "Expected 1 row after dropping rows but have %zu.\n", table3->n_rows);
+		goto cleanup;
+	}
+
+	status = 0;
+cleanup:
+	dt_table_free(&table);
+	dt_table_free(&table2);
+	dt_table_free(&table3);
+	return status;
+}


### PR DESCRIPTION
also fixed a bug with NULL vaues not being copied over after using dt_column_copy(...)