### PR TITLE
(#81) return const pointer from dt_table_get_value

### DIFF
--- a/include/DataTable.h
+++ b/include/DataTable.h
@@ -65,7 +65,7 @@ dt_table_set_value(
 	const void* const value);
 
 // get value at specified row/column index as a pointer
-void*
+const void*
 dt_table_get_value(
 	const struct DataTable* const table,
 	const size_t row,

--- a/src/DataTable_Internal.c
+++ b/src/DataTable_Internal.c
@@ -198,9 +198,9 @@ __filter_multiple(
 // To handle the different types, we use a couple macros defined above.
 static bool
 __two_values_equal(
-	void* value1,
+	const void* value1,
 	enum data_type_e value1_type,
-	void* value2,
+	const void* value2,
 	enum data_type_e value2_type)
 {
 	// if either is a string type, BOTH must be strings.
@@ -544,7 +544,7 @@ __transfer_row(
 
 	for (size_t i = 0; i < dest->n_columns; ++i)
 	{
-		void* value = dt_table_get_value(src, src_row_idx, i);
+		const void* value = dt_table_get_value(src, src_row_idx, i);
 		// be careful with unsigned subtraction...
 		size_t dest_row = dest->n_rows == 0 ? 0 : dest->n_rows - 1;
 		dt_table_set_value(dest, dest_row, i, value);

--- a/src/HashTable.c
+++ b/src/HashTable.c
@@ -15,7 +15,7 @@ hash_function(
 
 	for (size_t i = 0; i < table->n_columns; ++i)
 	{
-		void* value = dt_table_get_value(table, row_idx, i);
+		const void* value = dt_table_get_value(table, row_idx, i);
 
 		switch (table->columns[i].column->type)
 		{

--- a/test/DataTable/dt_table_append.c
+++ b/test/DataTable/dt_table_append.c
@@ -46,7 +46,7 @@ int main()
 	}
 
 	// VALIDATE COL1
-	int32_t* get;
+	const int32_t* get;
 	if ((get = dt_table_get_value(table, 0, 0)) && *get != 10)
 	{
 		fprintf(stderr, "Expected value at (0, 0) to be 10 but got %d.\n", *get);
@@ -84,7 +84,7 @@ int main()
 	}
 
 	// VALIDATE COL2
-	float* get2;
+	const float* get2;
 	if ((get2 = dt_table_get_value(table, 0, 1)) && fabsf(*get2 - 5.5f) > 0.0001f)
 	{
 		fprintf(stderr, "Expected value at (0, 1) to be 5.5 but got %f.\n", *get2);

--- a/test/DataTable/dt_table_apply_all.c
+++ b/test/DataTable/dt_table_apply_all.c
@@ -40,7 +40,7 @@ int main()
 	{
 		for (size_t r = 0; r < table->n_rows; ++r)
 		{
-			int32_t* get = dt_table_get_value(table, r, c);
+			const int32_t* get = dt_table_get_value(table, r, c);
 			if (*get != 20)
 			{
 				fprintf(stderr, "Expected value to be 20 but got %d.\n", *get);

--- a/test/DataTable/dt_table_apply_column.c
+++ b/test/DataTable/dt_table_apply_column.c
@@ -47,7 +47,7 @@ int main()
 	const char column_value_names[2][MAX_COL_LEN] = { "col1", "col2" };
 	dt_table_apply_column(table, "col3", &add_columns, NULL, column_value_names, 2);
 
-	int32_t* get = NULL;
+	const int32_t* get = NULL;
 	get = dt_table_get_value(table, 0, 2);
 	if (*get != 22)
 	{

--- a/test/DataTable/dt_table_fill_column.c
+++ b/test/DataTable/dt_table_fill_column.c
@@ -18,7 +18,7 @@ int main()
 	dt_table_fill_column_values_by_index(table, 0, &fill);
 	for (size_t i = 0; i < 5; ++i)
 	{
-		int32_t* get = dt_table_get_value(table, i, 0);
+		const int32_t* get = dt_table_get_value(table, i, 0);
 		if (*get != 10)
 		{
 			fprintf(stderr, "Expected value 10 but got %d.\n", *get);
@@ -31,7 +31,7 @@ int main()
 	dt_table_fill_column_values_by_name(table, "col1", &fill);
 	for (size_t i = 0; i < 5; ++i)
 	{
-		int32_t* get = dt_table_get_value(table, i, 0);
+		const int32_t* get = dt_table_get_value(table, i, 0);
 		if (*get != 20)
 		{
 			fprintf(stderr, "Expected value 20 but got %d.\n", *get);

--- a/test/DataTable/dt_table_filter.c
+++ b/test/DataTable/dt_table_filter.c
@@ -43,7 +43,7 @@ int main()
 		goto cleanup;
 	}
 
-	int32_t* get = dt_table_get_value(filtered_table, 0, 0);
+	const int32_t* get = dt_table_get_value(filtered_table, 0, 0);
 	if (*get != 10)
 	{
 		fprintf(stderr, "Expected value at (0, 0) to be 10 but got %d.\n", *get);

--- a/test/DataTable/dt_table_filter_AND.c
+++ b/test/DataTable/dt_table_filter_AND.c
@@ -53,7 +53,7 @@ int main()
 		goto cleanup;
 	}
 
-	int32_t* get_int = dt_table_get_value(filtered, 0, 0);
+	const int32_t* get_int = dt_table_get_value(filtered, 0, 0);
 	if (*get_int != 10)
 	{
 		fprintf(stderr, "Expected value at (0, 0) in filtered to be 10 but got %d.\n", *get_int);
@@ -67,7 +67,7 @@ int main()
 		goto cleanup;
 	}
 
-	float* get_float = dt_table_get_value(filtered, 0, 1);
+	const float* get_float = dt_table_get_value(filtered, 0, 1);
 	if (fabsf(*get_float - 5.5f) > 0.0001f)
 	{
 		fprintf(stderr, "Expected value at (0, 1) in filtered to be 5.5 but got %f.\n", *get_float);

--- a/test/DataTable/dt_table_filter_OR.c
+++ b/test/DataTable/dt_table_filter_OR.c
@@ -53,7 +53,7 @@ int main()
 		goto cleanup;
 	}
 
-	int32_t* get_int = dt_table_get_value(filtered, 0, 0);
+	const int32_t* get_int = dt_table_get_value(filtered, 0, 0);
 	if (*get_int != 20)
 	{
 		fprintf(stderr, "Expected value at (0, 0) in filtered to be 20 but got %d.\n", *get_int);
@@ -67,7 +67,7 @@ int main()
 		goto cleanup;
 	}
 
-	float* get_float = dt_table_get_value(filtered, 0, 1);
+	const float* get_float = dt_table_get_value(filtered, 0, 1);
 	if (fabsf(*get_float - 12.52f) > 0.0001f)
 	{
 		fprintf(stderr, "Expected value at (0, 1) in filtered to be 12.52 but got %f.\n", *get_float);

--- a/test/DataTable/dt_table_get_set_value.c
+++ b/test/DataTable/dt_table_get_set_value.c
@@ -17,7 +17,7 @@ int main()
 	set1 = 30;
 	dt_table_set_value(table, 0, 1, &set1);
 
-	int32_t* get = dt_table_get_value(table, 0, 1);
+	const int32_t* get = dt_table_get_value(table, 0, 1);
 	if (*get != 30)
 	{
 		fprintf(stderr, "Expected value to be 30 but got %d.\n", *get);

--- a/test/DataTable/dt_table_replace_null.c
+++ b/test/DataTable/dt_table_replace_null.c
@@ -38,7 +38,7 @@ int main()
 
 	}
 
-	int32_t* get = dt_table_get_value(table, 0, 1);
+	const int32_t* get = dt_table_get_value(table, 0, 1);
 	if (*get != 55)
 	{
 		fprintf(stderr, "Expected replaced value to be 55 but got %d.\n", *get);

--- a/test/DataTable/dt_table_select.c
+++ b/test/DataTable/dt_table_select.c
@@ -42,7 +42,7 @@ int main()
 		goto cleanup;
 	}
 
-	int32_t* get = dt_table_get_value(subset, 0, 0);
+	const int32_t* get = dt_table_get_value(subset, 0, 0);
 	if (*get != 10)
 	{
 		fprintf(stderr, "Expected first value in subset to be 10 but got %d.\n", *get);


### PR DESCRIPTION
return a const pointer to notify user that they should not be modifying the value directly and should instead use dt_table_set_value